### PR TITLE
SHIP-4548: switching to circle-ci dockerhub-context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,15 @@ workflows:
   build_and_push:
     jobs:
       - node-deploy-image:
+          context:
+            - dockerhub-secrets
           filters:
             branches:
               only:
                 - develop
       - golang-deploy-image:
+          context:
+            - dockerhub-secrets
           filters:
             branches:
               only:


### PR DESCRIPTION
switching from dockerhub env-vars to dockerhub-secrtes-context.
reason: in almost every circleci-project we have DOCKER_HUB_PASSWORD configured. so we are moving it to a context and reuse it everywhere